### PR TITLE
Updated pyhepmc_ng -> pyhepmc

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ install_requires =
     numpy
     vector
     networkx
-    pyhepmc_ng
+    pyhepmc 
     h5py
     pandas
     typicle


### PR DESCRIPTION
From pyhepmc "Please install pyhepmc, pyhepmc-ng is no longer updated."